### PR TITLE
Right click to edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This is what the extension can do for you:
 - Make negative numbers anywhere in the application have square corners so they stand out even more.
 - Larger Clickable Area for Icons: Makes the uncleared, cleared and reconciled icons easier to select.
 - Current month indicator to make it easier to see which month is the current month.
+- Right click on a transaction when in the Accounts view to display the Edit menu.
 
 All of these are configurable with options in the extension options page.
 

--- a/src/common/res/features/right-click-to-edit/main.css
+++ b/src/common/res/features/right-click-to-edit/main.css
@@ -1,0 +1,20 @@
+.modal-account-edit-transaction-list .modal-above .modal-arrow
+{
+	bottom: auto !important;
+	top: 100% !important;
+	border-bottom-color: transparent !important;
+	border-top-color: #fff !important;	
+}
+
+.modal-account-edit-transaction-list .modal-above li ul {
+	top: auto;
+	bottom: -15px;
+}
+
+/* Fix arrow position in Firefox */
+.modal-account-edit-transaction-list .arrow-right-1, 
+.modal-account-hide-column .arrow-right-1 {
+	position: absolute;
+	right: 11px;
+	top: 4px;
+}

--- a/src/common/res/features/right-click-to-edit/main.js
+++ b/src/common/res/features/right-click-to-edit/main.js
@@ -1,0 +1,82 @@
+(function poll() {
+  // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
+  if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.pageReady === true ) {
+
+    ynabToolKit.rightClickToEdit = new function ()  { // Keep feature functions contained within this
+    
+      function displayContextMenu(element, e)
+      {	
+		// clear all toggled checkboxes
+		$('.ynab-checkbox-button.is-checked').click();
+      	
+      	// toggle checkbox
+      	if ($(element).hasClass('ynab-grid-body-sub'))
+      	{
+      		// select parent transaction to toggle
+      		$(element).prevAll('.ynab-grid-body-parent:first').find('.ynab-checkbox-button').click();
+      	}
+      	else {
+      		// select current transaction to toggle
+	      	$(element).find('.ynab-checkbox-button').click();
+      	}
+      	
+      	// make context menu appear  	
+      	$('.accounts-toolbar-edit-transaction').click();
+      	
+      	// hide disabled buttons and dividers above them
+      	var parents = $('.modal-account-edit-transaction-list .modal-list .button-disabled').parent();
+      	var above = $(parents).prev();
+      	$(parents).hide();
+      	$(above).hide();
+      	
+      	// determine if modal needs to be positioned above or below clicked element
+      	var below = true;
+      	var height = $('.modal-account-edit-transaction-list .modal').outerHeight();
+      	if (e.pageY + height > $(window).height()) { var below = false; }
+      	
+      	// move context menu
+      	var offset = $(element).offset();
+      	if (below)
+      	{
+      		// position below
+      		$('.modal-account-edit-transaction-list .modal')
+	    		.addClass('modal-below')      		
+      			.css('left', e.pageX - 115)
+	      		.css('top', offset.top + 41);    			      			      		
+	    }
+	    else 
+	    {
+	    	// position above
+	    	$('.modal-account-edit-transaction-list .modal')
+	    		.addClass('modal-above')
+    			.css('left', e.pageX - 115)
+    			.css('top', offset.top - height - 8); 
+	    }
+      }
+      
+      function hideContextMenu() 
+      {
+        // ignore right clicks
+      	return false;
+      }
+      
+      
+      
+      this.invoke = function() {
+		$('.ynab-grid').on('contextmenu', '.ynab-grid-body-row', function(e) { displayContextMenu(this, e); return false; }); 
+		$('body').on('contextmenu', '.modal-account-edit-transaction-list', hideContextMenu);      
+      },
+      
+      this.observe = function(changedNodes) {
+      	if (changedNodes.has('ynab-grid-body')) {
+      		ynabToolKit.rightClickToEdit.invoke();
+      	}
+      };
+
+    }; // Keep feature functions contained within this
+    ynabToolKit.rightClickToEdit.invoke(); // Run once and activate setTimeOut()
+
+  } else {
+    setTimeout(poll, 250);
+  }
+})();

--- a/src/common/res/features/right-click-to-edit/settings.json
+++ b/src/common/res/features/right-click-to-edit/settings.json
@@ -1,0 +1,14 @@
+{
+         "name": "rightClickToEdit",
+         "type": "checkbox",
+      "default": true,
+      "section": "accounts",
+        "title": "Show Menu When Right Clicking On Transaction",
+  "description": "Right clicking on a transaction will show the contextual menu, allowing easy access to the Edit menu options.",
+      "actions": {
+                    "true": [
+                      "injectCSS", "main.css",
+                      "injectScript", "main.js"
+                    ]
+                 }
+}


### PR DESCRIPTION
Adds functionality so that a transaction can be right clicked on, and
the Edit context menu will appear in that spot. Tested and working in
Chrome and Safari.